### PR TITLE
foreach children visited twice when doing tree traversal

### DIFF
--- a/src/Htmlizer.js
+++ b/src/Htmlizer.js
@@ -155,19 +155,25 @@
                 if (isOpenTag) {
                     var val, match, tempFrag, inner;
                     if (node.nodeType === 1) { //element
-                        var bindOpts = node.getAttribute(this.noConflict ? 'data-htmlizer' : 'data-bind');
+                        var beenThere = node.getAttribute('beenthere');
+                        if (beenThere) {
+                            node.setAttribute('beenthere', beenThere + 'y');
+                        } else {
+                            node.setAttribute('beenthere', 'y');
+                            var bindOpts = node.getAttribute(this.noConflict ? 'data-htmlizer' : 'data-bind');
 
-                        if (bindOpts) {
-                            node.removeAttribute(this.noConflict ? 'data-htmlizer' : 'data-bind');
-                            var conflict = [];
-                            this.forEachObjectLiteral(bindOpts, function (binding) {
-                                if (binding in conflictingBindings) {
-                                    conflict.push(binding);
+                            if (bindOpts) {
+                                //node.removeAttribute(this.noConflict ? 'data-htmlizer' : 'data-bind');
+                                var conflict = [];
+                                this.forEachObjectLiteral(bindOpts, function (binding) {
+                                    if (binding in conflictingBindings) {
+                                        conflict.push(binding);
+                                    }
+                                });
+                                if (conflict.length > 1) {
+                                    throw new Error('Multiple bindings (' + conflict[0] + ' and ' + conflict[1] + ') are trying to control descendant bindings of the same element.' +
+                                        'You cannot use these bindings together on the same element.');
                                 }
-                            });
-                            if (conflict.length > 1) {
-                                throw new Error('Multiple bindings (' + conflict[0] + ' and ' + conflict[1] + ') are trying to control descendant bindings of the same element.' +
-                                    'You cannot use these bindings together on the same element.');
                             }
                         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,26 @@ var assert = require("assert"),
     jsdom = require('jsdom').jsdom,
     jqueryFactory = require('../src/jquery.js');
 
+describe('visit same node twice', function () {
+    it('should... ', function () {
+        var template = [
+            '<ul data-bind="foreach: list">',
+            '<li data-bind="text: title"></li>',
+            '</ul>'
+        ].join('');
+        var outputHtml = (new Htmlizer(template)).toString({
+            list: [
+                { title: 'foo' },
+                { title: 'bar' },
+                { title: 'qux' }
+            ]
+        });
+        var df = htmlToDocumentFragment(outputHtml);
+
+        assert.equal('y', df.firstChild.children[0].getAttribute('beenthere'));
+    });
+});
+
 describe('run text and attr binding test', function () {
     var html = fetch('test/text-and-attr-binding-tpl.html'),
         outputHtml = (new Htmlizer(html)).toString({


### PR DESCRIPTION
I'm using Htmlizer in an attempt to create a partially server side rendered knockout application. I needed a way to keep the data-bindings, so that I can have knockout pick up where the server left.

Not removing the data-bind attributes causes an error in `foreach` bindings. they are visited twice, and the second time around, htmlizer will attempt to apply the bindings against the parent context, instead the foreached list it did in the first time. That second pass will either cause very weird bugs or it will not work at all.

I didn't yet take time to try and properly introduce an option to keep the bindings in place after applying them with HTMLizer - but it should probably be introduced in a more elegant way than what I did here. It just seems that it is indicative of a larger problem with the tree traversal algorithm.

This pull request is not intended for merging, as it is a hack to make the problem visible (and make it work for my use case for now). When looking on the output of htmlizer you can tell that children of a node with a foreach binding will have two `y`s in their `beenthere` attribute.

@papandreou mentioned that there has been some performance problems, and this double traversal could explain some parts of that at least.

I added a test with an example of the wrong behaviour. Another test broke as a side effect of the change, but I didn't change that.