### PR TITLE
Fix 'attr' binding using the '$index' from the 'foreach' binding

### DIFF
--- a/test/foreach-and-attr/foreach-and-attr-binding-tpl.html
+++ b/test/foreach-and-attr/foreach-and-attr-binding-tpl.html
@@ -1,0 +1,4 @@
+<div data-bind="foreach: {data: items, as: 'obj'}">
+    <div data-bind="attr: {'foo': $index }"></div>
+    <div data-bind="text: $index"></div>
+</div>

--- a/test/foreach-and-attr/test.js
+++ b/test/foreach-and-attr/test.js
@@ -1,0 +1,12 @@
+module.exports = function (Htmlizer, assert, util) {
+    describe('run inline "foreach" and "attr" statement test', function () {
+        var html = util.fetch('test/foreach-and-attr/foreach-and-attr-binding-tpl.html'),
+            outputHtml = (new Htmlizer(html)).toString({
+                items: ['item1', 'item2', 'item3']
+            }),
+            df = util.htmlToDocumentFragment(outputHtml);
+        it('it should have 4 HTMLElements', function () {
+            assert.equal(4, util.countElements(df));
+        });
+    });
+};

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,8 @@ require('./if/test.js')(Htmlizer, assert, util);
 
 require('./foreach/test.js')(Htmlizer, assert, util);
 
+require('./foreach-and-attr/test.js')(Htmlizer, assert, util);
+
 require('./css-and-style/test.js')(Htmlizer, assert, util);
 
 require('./with/test.js')(Htmlizer, assert, util);


### PR DESCRIPTION
Currently this PR only contains a failing test ;)
The idea is to fix this behaviour, I'm trying to dig into why it fails now.

```
src/Htmlizer.js:941
            return str.replace(/>/g, "&gt;").replace(/</g, "&lt;");
                       ^

TypeError: str.replace is not a function
    at Object.Htmlizer.htmlEncode (src/Htmlizer.js:941:24)
    at Object.Htmlizer.generateAttribute (src/Htmlizer.js:945:24)
    at Object.Htmlizer.inlineBindings.attr (src/Htmlizer.js:634:52)
    at Object.eval (eval at <anonymous> (src/Htmlizer.js:1066:21), <anonymous>:39:72)
    at Object.<anonymous> (src/Htmlizer.js:763:39)
    at Array.forEach (native)
    at Object.Htmlizer.executeForEach (src/Htmlizer.js:749:19)
    at Object.Htmlizer.inlineBindings.foreach (src/Htmlizer.js:689:36)
    at Object.eval [as toString] (eval at <anonymous> (src/Htmlizer.js:1066:21), <anonymous>:20:75)
    at Suite.<anonymous> (test/foreach-and-attr/test.js:4:47)
    at context.describe.context.context (node_modules/mocha/lib/interfaces/bdd.js:73:10)
    at module.exports (test/foreach-and-attr/test.js:2:5)
    at Object.<anonymous> (test/test.js:23:38)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at node_modules/mocha/lib/mocha.js:172:27
    at Array.forEach (native)
    at Mocha.loadFiles (node_modules/mocha/lib/mocha.js:169:14)
    at Mocha.run (node_modules/mocha/lib/mocha.js:356:31)
    at Object.<anonymous> (node_modules/mocha/bin/_mocha:359:16)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
```