### PR TITLE
Add failing test for data-bind on script and style tags

### DIFF
--- a/src/Htmlizer.js
+++ b/src/Htmlizer.js
@@ -164,7 +164,7 @@
                 }
 
                 if (!isOpenTag) {
-                    if (node.type === 'tag' && !voidTags[node.name]) {
+                    if ((node.type === 'tag'  || node.type === 'script' || node.type === 'style') && !voidTags[node.name]) {
                         //Generate closing tag
                         funcBody += CODE(function (output, tag) {
                             output += '</' + $$(tag) + '>';
@@ -176,10 +176,16 @@
                 var val, match, tempFrag, inner;
                 if (node.type === 'text') {
                     //TODO: Write test for text htmlEncode
-                    funcBody += CODE(function (text, output) {
-                        output += this.htmlEncode($$(text));
-                    }, {text: node.data});
-                } else if (node.type === 'tag') {
+                    if (node.parent && (node.parent.type === 'script' || node.parent.type === 'style')) {
+                        funcBody += CODE(function (text, output) {
+                            output += $$(text);
+                        }, {text: node.data});
+                    } else {
+                        funcBody += CODE(function (text, output) {
+                            output += this.htmlEncode($$(text));
+                        }, {text: node.data});
+                    }
+                } else if (node.type === 'tag' || node.type === 'script' || node.type === 'style') {
                     //Generate open tag (without attributes and >)
                     funcBody += CODE(function (output, tag) {
                         output += '<' + $$(tag);

--- a/test/text-and-attr/style-script-text-binding-tpl.html
+++ b/test/text-and-attr/style-script-text-binding-tpl.html
@@ -1,0 +1,3 @@
+<script data-bind="text: 'foo;'"></script>
+<style data-bind="text: '.foo { display: inline-block; }'"></style>
+<div data-bind="text: 'hello'"></div>

--- a/test/text-and-attr/style-script-text-binding-tpl.html
+++ b/test/text-and-attr/style-script-text-binding-tpl.html
@@ -1,3 +1,5 @@
 <script data-bind="text: 'foo;'"></script>
 <style data-bind="text: '.foo { display: inline-block; }'"></style>
+<script>var foo = 'bar';</script>
+<script><div></div></script>
 <div data-bind="text: 'hello'"></div>

--- a/test/text-and-attr/test.js
+++ b/test/text-and-attr/test.js
@@ -33,6 +33,8 @@ module.exports = function (Htmlizer, assert, util) {
         it('it should have executed text binding on style and script tag, and removed the "data-bind" attribute', function () {
             assert.equal(outputHtml, "<script>foo;</script>\n" +
                 "<style>.foo { display: inline-block; }</style>\n" +
+                "<script>var foo = 'bar';</script>\n" +
+                "<script><div></div></script>\n" +
                 "<div>hello</div>");
         });
     });

--- a/test/text-and-attr/test.js
+++ b/test/text-and-attr/test.js
@@ -26,6 +26,17 @@ module.exports = function (Htmlizer, assert, util) {
         });
     });
 
+    describe('run data-bind:text on style and script tags test', function () {
+        var html = util.fetch('test/text-and-attr/style-script-text-binding-tpl.html'),
+            outputHtml = (new Htmlizer(html)).toString(),
+            df = util.htmlToDocumentFragment(outputHtml);
+        it('it should have executed text binding on style and script tag, and removed the "data-bind" attribute', function () {
+            assert.equal(outputHtml, "<script>foo;</script>\n" +
+                "<style>.foo { display: inline-block; }</style>\n" +
+                "<div>hello</div>");
+        });
+    });
+
     describe('run text binding on top-level test', function () {
         it('should render the end tag when there is a text binding on the top level element', function () {
             assert.equal(new Htmlizer('<b data-bind="text: name">bogus</b>').toString({ name: 'foo' }), '<b>foo</b>');


### PR DESCRIPTION
Found another issue when migrating our app - data-binds on style and script tags are currently not supported, but our app is using that so we can dynamically populate them.

I've also looked how this could possibly be supported, and put that change in a separate commit - but you may have a better idea how to fix it.